### PR TITLE
/name functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-Adds /name functionality, including regex for numbers, brackets, parantheses, and spaces, capabilities for one name, and a max length of 30 characters.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+Adds /name functionality, including regex for numbers, brackets, parantheses, and spaces, capabilities for one name, and a max length of 30 characters.

--- a/media/lua/client/tics/client/network/ClientRecv.lua
+++ b/media/lua/client/tics/client/network/ClientRecv.lua
@@ -190,11 +190,30 @@ ClientRecv['RollResult'] = function(args)
     ISChat.onDiceResult(username, characterName, diceCount, diceType, addCount, diceResults, finalResult)
 end
 
+ClientRecv["OverheadNameChange"] = function(args) -- Shows new name over player's head
+    local onlineID     = args.onlineID
+    local overheadName = args.overheadName
+    if not onlineID or not overheadName then
+        print("TICS error: OverheadNameChange packet missing data.")
+        return
+    end
+    local targetPlayer = getPlayerByOnlineID(onlineID)
+    if targetPlayer then
+        targetPlayer:setName(overheadName)
+        print("Updated overhead name to: " .. overheadName .. " for onlineID " .. onlineID)
+    else
+        print("TICS error: No player found with onlineID:", onlineID)
+    end
+end
+
+
+
 function OnServerCommand(module, command, args)
     if module == 'TICS' and ClientRecv[command] then
         ClientRecv[command](args)
     end
 end
+
 
 Events.OnServerCommand.Add(OnServerCommand)
 

--- a/media/lua/client/tics/client/network/ClientSend.lua
+++ b/media/lua/client/tics/client/network/ClientSend.lua
@@ -94,6 +94,10 @@ function ClientSend.sendMuteRadio(radio, state)
     end
 end
 
+function ClientSend.sendChangeName(fullName) -- Sending ChangeName to server
+    ClientSendCommand('ChangeName', { fullName = fullName }) -- Send fullName as fullName
+end
+
 -- only for belt items
 function ClientSend.sendGiveRadioState(radio)
     if not isClient() then return end

--- a/media/lua/client/tics/client/overriden/ISChat.lua
+++ b/media/lua/client/tics/client/overriden/ISChat.lua
@@ -1411,7 +1411,6 @@ end
 
 -- TODO: try to clean this mess copied from the base game
 ISChat.addLineInChat = function(message, tabID)
-    print("DEBUG TICS: Raw message line received in addLineInChat:", message:getTextWithPrefix())
     if UdderlyUpToDate and
         message.setOverHeadSpeech == nil and
         message.isFromDiscord == nil and

--- a/media/lua/server/tics/server/network/ServerRecv.lua
+++ b/media/lua/server/tics/server/network/ServerRecv.lua
@@ -80,6 +80,9 @@ RecvServer['ChatMessage'] = function(player, args)
     ChatMessage.ProcessMessage(player, args, 'ChatMessage', true)
 end
 
+RecvServer['ChangeName'] = function(player, args)
+    ChatMessage.ChangeName(player, args.fullName) -- Pass args.fullName to ChatMessage.ChangeName
+end
 
 RecvServer['Typing'] = function(player, args)
     ChatMessage.ProcessMessage(player, args, 'Typing', false)

--- a/media/lua/shared/Translate/EN/UI_EN.txt
+++ b/media/lua/shared/Translate/EN/UI_EN.txt
@@ -1,4 +1,5 @@
 UI_EN = {
+    UI_name_change_roleplaychat = "Name changed to ",
     UI_TICS_chat_enable_voices  = "Enable voices",
     UI_TICS_chat_disable_voices = "Disable voices",
     UI_TICS_enable_radio_icon   = "Show radio icon",

--- a/media/sandbox-options.txt
+++ b/media/sandbox-options.txt
@@ -309,6 +309,14 @@ option TICS.YellColor
 	page = TICSChannels,
 	translation = TICS_YellColor,
 }
+option TICS.NameChangeEnabled
+{
+	type = boolean,
+	default = true,
+
+	page = TICSChannels,
+	translation = TICS_NameChangeEnabled,
+}
 
 option TICS.PrivateMessageEnabled
 {


### PR DESCRIPTION
Hello! This is /name functionality that allows for names that do not exceed 30 characters, as well as numbers, brackets, parantheses, and dashes / hyphens. It also allows for multiple or one word names such as 'John' or 'John the Guy'. 

This is also probably not the most optimal way to do this, as I am extremely new to PZ modding and about 85% of this was course-corrected with the assistance of AI. (necessity since our server is moving on from a mod that allows /name to TICS)

It currently does not have a sandbox option to toggle on/off (easy enough to fix), and while name updates will show for other players, currently the messages to say "your name has been changed to: " only shows locally instead of being broadcasted.